### PR TITLE
Multi-architecture Linux & macOS builds

### DIFF
--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -58,6 +58,35 @@ install_ruby() {
   rm -rf ${ruby_install}
 }
 
+set_macos_host_flags() {
+  local macos_host_arch=$1
+
+  if [ -z "$macos_host_arch" ]; then
+    echo "No macOS host architecture specified. Assuming Linux or other non-macOS environment."
+    return 0
+  fi
+
+  echo "Detected macOS host architecture: $macos_host_arch"
+  ARCH=$(uname -m)
+
+  case "$ARCH" in
+    x86_64)
+      echo "Running under Rosetta 2 emulation"
+      export LG_VADDR=39
+      ;;
+    arm64)
+      echo "Running natively on ARM64"
+      export LG_VADDR=39
+      ;;
+    *)
+      echo "Unknown architecture: $ARCH"
+      exit 1
+      ;;
+  esac
+
+  echo "LG_VADDR set to $LG_VADDR"
+}
+
 DIR0=$( dirname "$0" )
 DIR_TOOLS=$( cd "$DIR0" && pwd )
 

--- a/ubuntu-20.04.Dockerfile
+++ b/ubuntu-20.04.Dockerfile
@@ -65,16 +65,19 @@ ENV TEBAKO_PREFIX=/root/.tebako
 FROM base AS base-ruby
 LABEL stage="base-ruby"
 
-# ARG macos_host_arch
-ARG ruby_version="3.3.6"
+# Default build-time argument
+ARG ruby_version=3.3.6
+
+# Persistent environment variable
+ENV TEBAKO_RUBY_VERSION=$ruby_version
 
 # Set macOS-specific flags and install Ruby
 # RUN /opt/tools/tools.sh set_macos_host_flags "$macos_host_arch" && \
 #     gem install tebako && \
-#     tebako setup -R ${ruby_version}
+#     tebako setup -R $TEBAKO_RUBY_VERSION
 
 RUN gem install tebako -v 0.12.2.rc1 && \
-    tebako setup -R ${ruby_version}
+    tebako setup -R "$TEBAKO_RUBY_VERSION"
 
 # Test Layer
 FROM base-ruby AS test
@@ -82,8 +85,8 @@ LABEL stage="test"
 
 # Copy test files and execute tests
 COPY test /root/test
-RUN tebako press -R ${ruby_version} -r /root/test -e tebako-test-run.rb -o ruby-${ruby_version}-package && \
-    rm ruby-${ruby_version}-package
+RUN tebako press -R "$TEBAKO_RUBY_VERSION" -r /root/test -e tebako-test-run.rb -o "ruby-$TEBAKO_RUBY_VERSION-package" && \
+    rm "ruby-$TEBAKO_RUBY_VERSION-package"
 
 # Final Production Image
 FROM base-ruby AS builder

--- a/ubuntu-20.04.Dockerfile
+++ b/ubuntu-20.04.Dockerfile
@@ -74,7 +74,7 @@ ARG ruby_version="3.3.6"
 #     gem install tebako && \
 #     tebako setup -R ${ruby_version}
 
-RUN gem install tebako && \
+RUN gem install tebako -v 0.12.2.rc1 && \
     tebako setup -R ${ruby_version}
 
 # Test Layer

--- a/ubuntu-20.04.Dockerfile
+++ b/ubuntu-20.04.Dockerfile
@@ -27,7 +27,6 @@ FROM ubuntu:focal AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
-ENV ARCH=x64
 
 RUN apt-get -y update && \
     apt-get -y install sudo wget git make pkg-config clang-12 clang++-12            \

--- a/ubuntu-20.04.Dockerfile
+++ b/ubuntu-20.04.Dockerfile
@@ -65,8 +65,11 @@ ARG macos_host_arch
 ARG ruby_version="3.3.6"
 
 # Set macOS-specific flags and install Ruby
-RUN /opt/tools/tools.sh set_macos_host_flags "$macos_host_arch" && \
-    gem install tebako && \
+# RUN /opt/tools/tools.sh set_macos_host_flags "$macos_host_arch" && \
+#     gem install tebako && \
+#     tebako setup -R ${ruby_version}
+
+RUN gem install tebako && \
     tebako setup -R ${ruby_version}
 
 # Test Layer

--- a/ubuntu-20.04.Dockerfile
+++ b/ubuntu-20.04.Dockerfile
@@ -47,6 +47,11 @@ COPY tools /opt/tools
 RUN /opt/tools/tools.sh install_cmake && \
     /opt/tools/tools.sh install_ruby
 
+# This is needed to deal with gems created by `bundler gem` that are
+# being packaged by `tebako press` inside of a container. More at
+# https://github.com/tamatebako/tebako/issues/233#issuecomment-2593760210.
+RUN git config --global --add safe.directory '*'
+
 # https://github.com/actions/checkout/issues/1014
 # RUN adduser --disabled-password --gecos "" --home $HOME tebako && \
 #    printf "\ntebako\tALL=(ALL)\tNOPASSWD:\tALL" > /etc/sudoers.d/tebako
@@ -61,7 +66,7 @@ ENV TEBAKO_PREFIX=/root/.tebako
 FROM base AS base-ruby
 LABEL stage="base-ruby"
 
-ARG macos_host_arch
+# ARG macos_host_arch
 ARG ruby_version="3.3.6"
 
 # Set macOS-specific flags and install Ruby


### PR DESCRIPTION
# Context

I'm working on a CI build matrix for a project. For it I need:

* macos-x86_64
* macos-arm64
* ubuntu-x86_64
* ubuntu-arm64

Since qemu builds on macOS arm hardware doesn't quite work, I'm running all intel builds on a macOS intel host and all arm builds on a macOS arm host.

I'm pleased to say that I have that working with the changes in this PR.

# Changes

For this PR, I've done a few things to the Ubuntu docker image:

## Named layers so the `test` wouldn't leave files in the image.

The test runs, but it's not included in the production image.

## Removed the `ARCH` variable so that it can detect the architecture and install the appropriate version of CMAKE.

This means I can build arm64 macOS and Ubuntu images on an M2 Mac.

It also means I can build x86_64 macOS and Ubuntu images on an Intel Mac.

*This does not fix the QEMU jmalloc issue at https://github.com/tamatebako/tebako-ci-containers/issues/49*

## Sets a `TEBAKO_RUBY_VERSION` variable in the contianer

This is needed because `ARG` can't persist across layers.

# Consequences

This should drop-in to the current CI images; however the removal of the `ARCH` that was hard coded means it might need to be moved into the `yaml` files for the runner if an override is needed for any reason (it shouldn't).

# Considerations

I think the `tebako press` CLI should run via ENV vars. I set `TEBAKO_RUBY_VERSION=3.3.6`, so this should be possible and it should run:

```
TEBAKO_RUBY_VERSION=3.3.6 TEBAKO_ENTRPOINT=foo TEBAKO_ROOT=/mnt/w TEBAKO_OUTPUT=/mnt/w tebako press
```

That means I could set the `TEBAKO_RUBY_VERSION` in the container and it would run the pre-installed version without the user specifying anything. This might also mean if tebako wants to maintain an image repository for prebuilt compilers, they'd have to start maintaining versions like `ubuntu-ruby:3.3.6`, etc.
