### PR TITLE
WIP support centos 7.9.2009 as a build CI container

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -57,6 +57,7 @@ jobs:
         container:
           - 'ubuntu-20.04'
           - 'alpine-3.17'
+          - 'centos-7.9.2009'
         architecture:
           - { host: 'ubuntu-22.04', platform: linux/amd64, suffix: 'x64', suffix2: 'amd64' }
           - { host: 'ubuntu-22.04-arm', platform: linux/arm64, suffix: 'arm64', suffix2: 'arm64' }

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -25,7 +25,7 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 
 # RPMs
 
-RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel jemalloc-devel libiberty-devel double-conversion-devel lz4-devel xz\
+RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel libiberty-devel double-conversion-devel lz4-devel xz\
 -devel openssl11-devel openssl11-static openssl11 libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
 
 ENV OPENSSL_ROOT_DIR=/usr/include/openssl11
@@ -33,8 +33,19 @@ ENV OPENSSL_ROOT_DIR=/usr/include/openssl11
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
 
-# missing things we have to build from source
+# places to drop things we have to build from source
 RUN mkdir -p /missing/dist /missing/src
+
+# missing things we have to build from source
+ADD https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 /missing/dist/jemalloc.tar.bz2
+RUN tar xjf /missing/dist/jemalloc.tar.bz2 -C /missing/src && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/jemalloc* && \
+    ./configure && \
+    make && \
+    make install && \
+    cd / && rm -rf /missing/src/jemalloc*
+
 ADD https://github.com/fmtlib/fmt/releases/download/11.1.4/fmt-11.1.4.zip /missing/dist/fmt.zip
 RUN unzip /missing/dist/fmt.zip -d /missing/src && \
     source /opt/rh/devtoolset-11/enable && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -48,6 +48,14 @@ RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
     make install && \
     cd / && rm -rf /missing/src/openssl*
 
+ADD https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2 /missing/dist/boost.tar.bz2
+RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/boost* && \
+    ./bootstrap.sh && \
+    ./b2 --without-python install && \
+    cd / && rm -rf /missing/src/boost*
+
 ADD https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 /missing/dist/jemalloc.tar.bz2
 RUN tar xjf /missing/dist/jemalloc.tar.bz2 -C /missing/src && \
     source /opt/rh/devtoolset-11/enable && \
@@ -102,14 +110,6 @@ RUN unzip /missing/dist/glog.zip -d /missing/src/ && \
     cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
     cmake --build . --config Release --target install && \
     cd / && rm -rf /missing/src/glog-*
-
-ADD https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2 /missing/dist/boost.tar.bz2
-RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \
-    source /opt/rh/devtoolset-11/enable && \
-    cd /missing/src/boost* && \
-    ./bootstrap.sh && \
-    ./b2 --without-python install && \
-    cd / && rm -rf /missing/src/boost*
 
 # Clone the utfcpp repository and copy headers to the include path
 RUN git clone https://github.com/nemtrif/utfcpp.git /usr/local/src/utfcpp && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -26,8 +26,7 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 # RPMs
 
 RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel jemalloc-devel libiberty-devel double-conversion-devel lz4-devel xz\
--devel openssl-devel libunwind-devel boost-devel boost-filesystem boost-program-options boost-system boost-iostreams boost-date-time boost-context boost-regex boost-thread brotli-devel libd\
-    warf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
+-devel openssl-devel libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
 
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
@@ -79,6 +78,13 @@ RUN unzip /missing/dist/glog.zip -d /missing/src/ && \
     cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
     cmake --build . --config Release --target install && \
     cd / && rm -rf /missing/src/glog-*
+
+ADD https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2 /missing/dist/boost.tar.bz2
+RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \
+    cd /missing/src/boost-* && \
+    ./bootstrap.sh && \
+    ./b2 install && \
+    cd / && rm -rf /missing/src/boost-*
 
 # Clone the utfcpp repository and copy headers to the include path
 RUN git clone https://github.com/nemtrif/utfcpp.git /usr/local/src/utfcpp && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -58,7 +58,7 @@ RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
     source /opt/rh/devtoolset-11/enable && \
     yum install -y python3 && \
     cd /missing/src/libdwarf* && \
-    ./configure && \
+    ./configure --enable-static --disable-shared && \
     make -j$(nproc) && \
     make check && \
     make install && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -26,9 +26,7 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 # RPMs
 
 RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel libiberty-devel double-conversion-devel lz4-devel xz\
--devel openssl11-devel openssl11-static openssl11 libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
-
-ENV OPENSSL_ROOT_DIR=/usr/include/openssl11
+-devel libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
 
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
@@ -37,6 +35,16 @@ RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
 RUN mkdir -p /missing/dist /missing/src
 
 # missing things we have to build from source
+ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
+ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz
+RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/openssl-* && \
+    ./Configure --prefix=$OPENSSL_ROOT_DIR && \
+    make && \
+    make install && \
+    cd / && rm -rf /missing/src/openssl*
+
 ADD https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 /missing/dist/jemalloc.tar.bz2
 RUN tar xjf /missing/dist/jemalloc.tar.bz2 -C /missing/src && \
     source /opt/rh/devtoolset-11/enable && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 # RPMs
 
 RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel libiberty-devel double-conversion-devel lz4-devel xz\
--devel libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
+-devel libunwind-devel libdwarf-devel elfutils-libelf-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
 
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -45,7 +45,7 @@ ADD https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-
 RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
     source /opt/rh/devtoolset-11/enable && \
     cd /missing/src/openssl-* && \
-    ./Configure --prefix=$OPENSSL_ROOT_DIR && \
+    ./Configure no-shared --prefix=$OPENSSL_ROOT_DIR && \
     make -j$(nproc) && \
     make install_sw install_dev && \
     cd / && rm -rf /missing/src/openssl* 

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -34,6 +34,9 @@ RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
 # places to drop things we have to build from source
 RUN mkdir -p /missing/dist /missing/src
 
+# ensure pkg-config finds stuff we install in /usr/local
+ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/local/lib/pkgconfig
+
 # missing things we have to build from source
 ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
 ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -41,13 +41,15 @@ ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/local/lib/pkgconfig
 ADD https://github.com/davea42/libdwarf-code/releases/download/v0.9.2/libdwarf-0.9.2.tar.xz /missing/dist/libdwarf.tar.xz
 RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
     source /opt/rh/devtoolset-11/enable && \
+    yum install -y python3 && \
     cd /missing/src/libdwarf* && \
     ./configure && \
     make -j$(nproc) && \
-    make check \
-    make install \
-    make installcheck \
-    cd / && rm -f /missing/src/libdwarf*
+    make check && \
+    make install && \
+    make installcheck && \
+    yum remove -y python3 && \
+    cd / && rm -rf /missing/src/libdwarf*
 
 ENV OPENSSL_ROOT_DIR=/usr/local/openssl1.1
 ADD https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1u/openssl-1.1.1u.tar.gz /missing/dist/openssl.tar.gz

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 # RPMs
 
 RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel libiberty-devel double-conversion-devel lz4-devel xz\
--devel libunwind-devel elfutils-libelf-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
+-devel openssl11-devel openssl11-static openssl11 libunwind-devel elfutils-libelf-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
 
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -71,7 +71,7 @@ RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \
     source /opt/rh/devtoolset-11/enable && \
     cd /missing/src/boost* && \
     ./bootstrap.sh && \
-    ./b2 --without-python install && \
+    ./b2 --without-python -j$(nproc) install && \
     cd / && rm -rf /missing/src/boost*
 
 ADD https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 /missing/dist/jemalloc.tar.bz2

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -46,9 +46,12 @@ RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
     source /opt/rh/devtoolset-11/enable && \
     cd /missing/src/openssl-* && \
     ./Configure --prefix=$OPENSSL_ROOT_DIR && \
-    make && \
-    make install && \
-    cd / && rm -rf /missing/src/openssl*
+    make -j$(nproc) && \
+    make install_sw install_dev && \
+    cd / && rm -rf /missing/src/openssl* 
+RUN echo $OPENSSL_ROOT_DIR/lib64 > /etc/ld.so.conf.d/openssl3.conf && \
+    ldconfig && \
+    $OPENSSL_ROOT_DIR/bin/openssl version
 
 ADD https://github.com/davea42/libdwarf-code/releases/download/v0.9.2/libdwarf-0.9.2.tar.xz /missing/dist/libdwarf.tar.xz
 RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -1,0 +1,111 @@
+FROM centos:centos7.9.2009
+ADD https://raw.githubusercontent.com/AtlasGondal/centos7-eol-repo-fix/refs/heads/main/CentOS-Base.repo /etc/yum.repos.d
+COPY vault-scl.repo /etc/yum.repos.d/
+RUN yum install -y epel-release
+RUN yum clean all && yum makecache
+RUN yum update -y
+
+#
+# Install tools needed by tebako
+#
+
+# Install devtoolset-11 stuff
+RUN    yum install -y devtoolset-11 devtoolset-11-elfutils-libelf-devel
+
+# Set environment variables for devtoolset-11
+RUN echo "source /opt/rh/devtoolset-11/enable" >> /etc/profile.d/devtoolset-11.sh
+
+# Verify installation (optional)
+RUN bash -c "source /opt/rh/devtoolset-11/enable && gcc --version"
+
+# Install cmake
+ARG CMAKE_VERSION=3.24.4
+RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-linux-x86_64.tar.gz | tar xz -C /usr/local/cmake --strip-components 1 && \
+    ln -s /usr/local/cmake/bin/cmake /usr/bin
+
+# RPMs
+
+RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel jemalloc-devel libiberty-devel double-conversion-devel lz4-devel xz\
+-devel openssl-devel libunwind-devel boost-devel boost-filesystem boost-program-options boost-system boost-iostreams boost-date-time boost-context boost-regex boost-thread brotli-devel libd\
+    warf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
+
+# Set environment variables for rh-ruby30 to be default ruby
+RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
+
+# missing things we have to build from source
+RUN mkdir -p /missing/dist /missing/src
+ADD https://github.com/fmtlib/fmt/releases/download/11.1.4/fmt-11.1.4.zip /missing/dist/fmt.zip
+RUN unzip /missing/dist/fmt.zip -d /missing/src && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/fmt* && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
+    cmake --build . --config Release --target install && \
+    cd / && rm -rf /missing/src/fmt*
+
+ADD https://github.com/google/double-conversion/archive/refs/tags/v3.3.1.zip /missing/dist/dc.zip
+RUN unzip /missing/dist/dc.zip -d /missing/src && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/double-conversion-* && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
+    cmake --build . --config Release --target install && \
+    cd / && rm -rf /missing/src/double-conversion-*
+
+ADD https://github.com/google/brotli/archive/refs/tags/v1.1.0.zip /missing/dist/brotli.zip
+RUN unzip /missing/dist/brotli.zip -d /missing/src/ && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/brotli-* && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
+    cmake --build . --config Release --target install && \
+    cd / && rm -rf /missing/src/brotli-*
+
+ADD https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.zip /missing/dist/gflags.zip
+RUN unzip /missing/dist/gflags.zip -d /missing/src/ && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/gflags-* && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
+    cmake --build . --config Release --target install && \
+    cd / && rm -rf /missing/src/gflags-*
+
+
+ADD https://github.com/google/glog/archive/refs/tags/v0.7.1.zip /missing/dist/glog.zip
+RUN unzip /missing/dist/glog.zip -d /missing/src/ && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/glog-* && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF .. && \
+    cmake --build . --config Release --target install && \
+    cd / && rm -rf /missing/src/glog-*
+
+# Clone the utfcpp repository and copy headers to the include path
+RUN git clone https://github.com/nemtrif/utfcpp.git /usr/local/src/utfcpp && \
+    mkdir -p /usr/local/include/utfcpp && \
+    cp -r /usr/local/src/utfcpp/source/* /usr/local/include/utfcpp/
+
+# Optional: Clean up unnecessary files
+RUN rm -rf /usr/local/src/utfcpp && \
+    yum clean all
+
+ENV TZ=Etc/UTC
+ARG ARCH=x64
+
+ENV CC=/opt/rh/devtoolset-11/root/usr/bin/gcc
+ENV CXX=/opt/rh/devtoolset-11/root/usr/bin/g++
+
+COPY tools /opt/tools
+
+RUN /opt/tools/tools.sh install_ruby
+
+ENV TEBAKO_PREFIX=/root/.tebako
+COPY test /root/test
+
+RUN gem install tebako
+#RUN tebako setup -R 3.3.7
+#RUN tebako setup -R 3.4.1
+#RUN tebako press -R 3.3.7 -r /root/test -e tebako-test-run.rb -o ruby-3.3.7-package
+#RUN tebako press -R 3.4.1 -r /root/test -e tebako-test-run.rb -o ruby-3.4.1-package
+# rm ruby-*-package
+

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -94,10 +94,11 @@ RUN unzip /missing/dist/glog.zip -d /missing/src/ && \
 
 ADD https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2 /missing/dist/boost.tar.bz2
 RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \
-    cd /missing/src/boost-* && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/boost* && \
     ./bootstrap.sh && \
-    ./b2 install && \
-    cd / && rm -rf /missing/src/boost-*
+    ./b2 --without-python install && \
+    cd / && rm -rf /missing/src/boost*
 
 # Clone the utfcpp repository and copy headers to the include path
 RUN git clone https://github.com/nemtrif/utfcpp.git /usr/local/src/utfcpp && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -26,7 +26,7 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 # RPMs
 
 RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel libiberty-devel double-conversion-devel lz4-devel xz\
--devel libunwind-devel libdwarf-devel elfutils-libelf-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
+-devel libunwind-devel elfutils-libelf-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget perl-IPC-Cmd
 
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30
@@ -38,6 +38,17 @@ RUN mkdir -p /missing/dist /missing/src
 ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
 # missing things we have to build from source
+ADD https://github.com/davea42/libdwarf-code/releases/download/v0.9.2/libdwarf-0.9.2.tar.xz /missing/dist/libdwarf.tar.xz
+RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/libdwarf* && \
+    ./configure && \
+    make -j$(nproc) && \
+    make check \
+    make install \
+    make installcheck \
+    cd / && rm -f /missing/src/libdwarf*
+
 ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
 ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz
 RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -38,6 +38,18 @@ RUN mkdir -p /missing/dist /missing/src
 ENV PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/local/lib/pkgconfig
 
 # missing things we have to build from source
+ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
+ENV PKG_CONFIG_PATH=$OPENSSL_ROOT_DIR/lib64/pkgconfig:$PKG_CONFIG_PATH
+ADD https://github.com/openssl/openssl/releases/download/openssl-3.0.16/openssl-3.0.16.tar.gz /missing/dist/openssl.tar.gz
+#ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz
+RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
+    source /opt/rh/devtoolset-11/enable && \
+    cd /missing/src/openssl-* && \
+    ./Configure --prefix=$OPENSSL_ROOT_DIR && \
+    make && \
+    make install && \
+    cd / && rm -rf /missing/src/openssl*
+
 ADD https://github.com/davea42/libdwarf-code/releases/download/v0.9.2/libdwarf-0.9.2.tar.xz /missing/dist/libdwarf.tar.xz
 RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
     source /opt/rh/devtoolset-11/enable && \
@@ -50,16 +62,6 @@ RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
     make installcheck && \
     yum remove -y python3 && \
     cd / && rm -rf /missing/src/libdwarf*
-
-ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
-ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz
-RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
-    source /opt/rh/devtoolset-11/enable && \
-    cd /missing/src/openssl-* && \
-    ./Configure --prefix=$OPENSSL_ROOT_DIR && \
-    make && \
-    make install && \
-    cd / && rm -rf /missing/src/openssl*
 
 ADD https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2 /missing/dist/boost.tar.bz2
 RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -26,7 +26,9 @@ RUN mkdir -p /usr/local/cmake && curl -Ls https://github.com/Kitware/CMake/relea
 # RPMs
 
 RUN yum install -y sudo git curl @Development pkgconfig bison flex autoconf binutils-devel libevent-devel acl libfmt-devel jemalloc-devel libiberty-devel double-conversion-devel lz4-devel xz\
--devel openssl-devel libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
+-devel openssl11-devel openssl11-static openssl11 libunwind-devel libdwarf-devel elfutils-libelf-devel glog-devel libffi-devel gdbm-devel libyaml-devel ncurses-devel readline-devel rh-ruby30 utfcpp unzip wget
+
+ENV OPENSSL_ROOT_DIR=/usr/include/openssl11
 
 # Set environment variables for rh-ruby30 to be default ruby
 RUN echo "source /opt/rh/rh-ruby30/enable" >> /etc/profile.d/rh-ruby30

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7.9.2009
+FROM centos:centos7.9.2009 AS base
 ADD https://raw.githubusercontent.com/AtlasGondal/centos7-eol-repo-fix/refs/heads/main/CentOS-Base.repo /etc/yum.repos.d
 COPY vault-scl.repo /etc/yum.repos.d/
 RUN yum install -y epel-release

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -132,7 +132,7 @@ RUN unzip /missing/dist/glog.zip -d /missing/src/ && \
 # Clone the utfcpp repository and copy headers to the include path
 RUN git clone https://github.com/nemtrif/utfcpp.git /usr/local/src/utfcpp && \
     mkdir -p /usr/local/include/utfcpp && \
-    cp -r /usr/local/src/utfcpp/source/* /usr/local/include/utfcpp/
+    cp -r /usr/local/src/utfcpp/source/* /usr/local/include/
 
 # Optional: Clean up unnecessary files
 RUN rm -rf /usr/local/src/utfcpp && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -83,7 +83,7 @@ RUN unzip /missing/dist/gflags.zip -d /missing/src/ && \
     cd / && rm -rf /missing/src/gflags-*
 
 
-ADD https://github.com/google/glog/archive/refs/tags/v0.7.1.zip /missing/dist/glog.zip
+ADD https://github.com/google/glog/archive/refs/tags/v0.4.0.zip /missing/dist/glog.zip
 RUN unzip /missing/dist/glog.zip -d /missing/src/ && \
     source /opt/rh/devtoolset-11/enable && \
     cd /missing/src/glog-* && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -49,13 +49,13 @@ RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
     make installcheck \
     cd / && rm -f /missing/src/libdwarf*
 
-ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
-ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz
-RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
+ENV OPENSSL_ROOT_DIR=/usr/local/openssl1.1
+ADD https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1u/openssl-1.1.1u.tar.gz /missing/dist/openssl.tar.gz
+RUN tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
     source /opt/rh/devtoolset-11/enable && \
     cd /missing/src/openssl-* && \
-    ./Configure --prefix=$OPENSSL_ROOT_DIR && \
-    make && \
+    ./Configure --prefix=$OPENSSL_ROOT_DIR linux-x86_64 && \
+    make -j$(nproc) && \
     make install && \
     cd / && rm -rf /missing/src/openssl*
 

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -73,6 +73,9 @@ RUN tar xjf /missing/dist/boost.tar.bz2 -C /missing/src && \
     ./bootstrap.sh && \
     ./b2 --without-python -j$(nproc) install && \
     cd / && rm -rf /missing/src/boost*
+RUN echo "/usr/local/lib" >> /etc/ld.so.conf.d/usrlocal.conf && \
+    echo "/usr/local/lib64" >> /etc/ld.so.conf.d/usrlocal.conf && \
+    ldconfig
 
 ADD https://github.com/jemalloc/jemalloc/releases/download/5.3.0/jemalloc-5.3.0.tar.bz2 /missing/dist/jemalloc.tar.bz2
 RUN tar xjf /missing/dist/jemalloc.tar.bz2 -C /missing/src && \

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -155,9 +155,13 @@ ENV TEBAKO_PREFIX=/root/.tebako
 COPY test /root/test
 
 RUN gem install tebako
-#RUN tebako setup -R 3.3.7
+COPY tebako-gem-centos.patch /tmp/
+RUN pushd $(dirname $(gem which tebako))/.. && \
+    patch -p1 < /tmp/tebako-gem-centos.patch && \
+    popd
+RUN tebako setup -R 3.3.7
+RUN tebako press -R 3.3.7 -r /root/test -e tebako-test-run.rb -o ruby-3.3.7-package
 #RUN tebako setup -R 3.4.1
-#RUN tebako press -R 3.3.7 -r /root/test -e tebako-test-run.rb -o ruby-3.3.7-package
 #RUN tebako press -R 3.4.1 -r /root/test -e tebako-test-run.rb -o ruby-3.4.1-package
 # rm ruby-*-package
 

--- a/centos-7.9.2009.Dockerfile
+++ b/centos-7.9.2009.Dockerfile
@@ -51,13 +51,13 @@ RUN tar xJf /missing/dist/libdwarf.tar.xz -C /missing/src && \
     yum remove -y python3 && \
     cd / && rm -rf /missing/src/libdwarf*
 
-ENV OPENSSL_ROOT_DIR=/usr/local/openssl1.1
-ADD https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1u/openssl-1.1.1u.tar.gz /missing/dist/openssl.tar.gz
-RUN tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
+ENV OPENSSL_ROOT_DIR=/usr/local/openssl3
+ADD https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz  /missing/dist/openssl.tar.gz
+RUN  tar xzf /missing/dist/openssl.tar.gz -C /missing/src/ && \
     source /opt/rh/devtoolset-11/enable && \
     cd /missing/src/openssl-* && \
-    ./Configure --prefix=$OPENSSL_ROOT_DIR linux-x86_64 && \
-    make -j$(nproc) && \
+    ./Configure --prefix=$OPENSSL_ROOT_DIR && \
+    make && \
     make install && \
     cd / && rm -rf /missing/src/openssl*
 

--- a/tebako-gem-centos.patch
+++ b/tebako-gem-centos.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f42fccf..f718c94 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -178,7 +178,7 @@ string(CONCAT RUBY_API_VER ${RUBY_VER_BASE} ".0")
+ #  list(GET LIBDWARFS_WR_VER_COMPONENTS 2 LIBDWARFS_WR_VER_PATCH)
+ #  set (LIBDWARFS_WR_VER_M ${LIBDWARFS_WR_VER_MAJOR}.${LIBDWARFS_WR_VER_MINOR}.${LIBDWARFS_WR_VER_PATCH})
+ #else(DWARFS_PRELOAD)
+-def_ext_prj_g(DWARFS_WR "v0.10.1")
++def_ext_prj_g(DWARFS_WR "centos7.9.2009")
+ #endif(DWARFS_PRELOAD)
+ 
+ def_ext_prj_g(PATCHELF "65e14792061c298f1d2bc44becd48a10cbf0bc81")
+@@ -277,7 +277,7 @@ else(DWARFS_PRELOAD)
+   ExternalProject_Add(${DWARFS_WR_PRJ}
+     GIT_SHALLOW true
+     PREFIX ${DEPS}
+-    GIT_REPOSITORY https://github.com/tamatebako/libdwarfs.git
++    GIT_REPOSITORY https://github.com/cleeland/libdwarfs.git
+     GIT_TAG ${DWARFS_WR_TAG}
+     SOURCE_DIR ${DWARFS_WR_SOURCE_DIR}
+     BINARY_DIR ${DWARFS_WR_BINARY_DIR}

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -57,7 +57,7 @@ install_ruby() {
   fi
   cd ruby-install-${RUBY_INSTALL_VERSION}
   make install
-  ruby-install --system ruby ${RUBY_VERSION} -- --without-gmp --disable-dtrace --disable-debug-env --disable-install-doc CC=${CC} ${RUBY_CFG_OPENSSL}
+  ruby-install --system ruby ${RUBY_VERSION} -- --without-gmp --disable-dtrace --disable-debug-env --disable-install-doc CC=${CC} #${RUBY_CFG_OPENSSL}
   popd
   rm -rf ${ruby_install}
 }

--- a/tools/tools.sh
+++ b/tools/tools.sh
@@ -51,9 +51,13 @@ install_ruby() {
   pushd ${ruby_install}
   wget -nv https://github.com/postmodern/ruby-install/releases/download/v${RUBY_INSTALL_VERSION}/ruby-install-${RUBY_INSTALL_VERSION}.tar.gz && \
   tar -xzvf ruby-install-${RUBY_INSTALL_VERSION}.tar.gz
+  if [ -n "$OPENSSL_ROOT_DIR" ]
+  then
+      RUBY_CFG_OPENSSL="--with-openssl-dir=${OPENSSL_ROOT_DIR}"
+  fi
   cd ruby-install-${RUBY_INSTALL_VERSION}
   make install
-  ruby-install --system ruby ${RUBY_VERSION} -- --without-gmp --disable-dtrace --disable-debug-env --disable-install-doc CC=${CC}
+  ruby-install --system ruby ${RUBY_VERSION} -- --without-gmp --disable-dtrace --disable-debug-env --disable-install-doc CC=${CC} ${RUBY_CFG_OPENSSL}
   popd
   rm -rf ${ruby_install}
 }

--- a/vault-scl.repo
+++ b/vault-scl.repo
@@ -1,0 +1,7 @@
+# /etc/yum.repos.d/CentOS-SCL.repo
+
+[scl-rh]
+name=CentOS-$releasever - SCL-RH
+baseurl=http://vault.centos.org/7.9.2009/sclo/$basearch/rh
+gpgcheck=1
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-SCLo


### PR DESCRIPTION
This PR is still a work-in-progress, but it's definitely far enough along to demonstrate potential, as it is able to complete `tebako setup -R 3.3.7`.

Thus far, changes required to support centos 7.9.2009 include:
1. an integrated base image of centos 7.9.2009 with a recent enough toolchain (`devtoolset-11`) and libraries (built during image build and catalogued in `/missing` inside the image) to build tools required by tebako.
2. changes to [libdwarfs](https://github.com/cleeland/libdwarfs) for detecting a non-system OpenSSL and propagating it to...
3. a changed [dwarfs](https://github.com/cleeland/dwarfs] that will use a non-system OpenSSL if provided

These changes are not yet sufficient to successfully run `tebako press ...`.  This fails when it tries to link ruby in the packaging "finalizer" step, because it tries to link to static versions of system libraries, and centos does not offer those in its packages.

At this point I could use some guidance and feedback.